### PR TITLE
Fixed a bug where it causes fields to be empty on Wordpress 4.8.x

### DIFF
--- a/includes.php
+++ b/includes.php
@@ -109,7 +109,7 @@ if ($desc['type'] == 'filter')
 
 	$fields = array();
 	foreach ($args as $arg) {
-		if (preg_match('[A-Z]+',$arg))
+		if (preg_match('/[A-Z]+/',$arg))
 			$fields = array_merge($fields,hookpress_get_fields($arg));
 		else
 			$fields[] = $arg;


### PR DESCRIPTION
 This plugin is broken for wordpress 4.8.2 as reported here https://wordpress.org/support/topic/plugin-is-broken-21/

I've provided a fix to make it possible to select fields.

This commit will fix it.